### PR TITLE
Implement endianness-indepenent output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lz4
 
 # IDE / editors files
 .clang_complete
+.vscode
 _codelite/
 _codelite_lz4/
 bin/

--- a/build/meson/meson/meson.build
+++ b/build/meson/meson/meson.build
@@ -81,6 +81,15 @@ if get_option('memory-usage') > 0
   compile_args += '-DLZ4_MEMORY_USAGE=@0@'.format(get_option('memory-usage'))
 endif
 
+if get_option('endianness-independent-output')
+  if get_option('default_library') != 'static'
+    error('Endianness-independent output can only be enabled in static builds')
+  endif
+
+  add_project_arguments('-DLZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT')
+  compile_args += '-DLZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT'
+endif
+
 if get_option('unstable')
   add_project_arguments('-DLZ4_STATIC_LINKING_ONLY', language: 'c')
   compile_args += '-DLZ4_STATIC_LINKING_ONLY'

--- a/build/meson/meson_options.txt
+++ b/build/meson/meson_options.txt
@@ -18,6 +18,8 @@ option('disable-memory-allocation', type: 'boolean', value: false,
   description: 'See LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION. Static builds only')
 option('distance-max', type: 'integer', min: 0, max: 65535, value: 65535,
   description: 'See LZ4_DISTANCE_MAX')
+option('endianness-independent-output', type: 'boolean', value: false,
+  description: 'See LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT. Static builds only')
 option('examples', type: 'boolean', value: false,
   description: 'Enable examples')
 option('fast-dec-loop', type: 'feature', value: 'auto',

--- a/lib/README.md
+++ b/lib/README.md
@@ -111,7 +111,8 @@ The following build macro can be selected to adjust source code behavior at comp
 - `LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT` : experimental feature aimed at producing the same
   compressed output on platforms of different endianness (i.e. little-endian and big-endian).
   Output on little-endian platforms shall remain unchanged, while big-endian platforms will start producing
-  the same output as little-endian. This isn't expected to impact backward- and forward-compatibility in any way.
+  the same output as little-endian ones. This isn't expected to impact backward- and forward-compatibility
+  in any way.
 
 - `LZ4_FREESTANDING` : by setting this build macro to 1,
   LZ4/HC removes dependencies on the C standard library,

--- a/lib/README.md
+++ b/lib/README.md
@@ -108,6 +108,11 @@ The following build macro can be selected to adjust source code behavior at comp
   Remove support of dynamic memory allocation.
   For more details, see description of this macro in `lib/lz4.c`.
 
+- `LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT` : experimental feature aimed at producing the same
+  compressed output on platforms of different endianness (i.e. little-endian and big-endian).
+  Output on little-endian platforms shall remain unchanged, while big-endian platforms will start producing
+  the same output as little-endian. This isn't expected to impact backward- and forward-compatibility in any way.
+
 - `LZ4_FREESTANDING` : by setting this build macro to 1,
   LZ4/HC removes dependencies on the C standard library,
   including allocation functions and `memmove()`, `memcpy()`, and `memset()`.

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -431,6 +431,16 @@ static U16 LZ4_readLE16(const void* memPtr)
     }
 }
 
+static U32 LZ4_readLE32(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read32(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        return (U32)p[0] + (p[1]<<8) + (p[2]<<16) + (p[3]<<24);
+    }
+}
+
 static void LZ4_writeLE16(void* memPtr, U16 value)
 {
     if (LZ4_isLittleEndian()) {
@@ -779,7 +789,7 @@ LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
 LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
 {
     if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
-    return LZ4_hash4(LZ4_read32(p), tableType);
+    return LZ4_hash4(LZ4_readLE32(p), tableType);
 }
 
 LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -431,6 +431,7 @@ static U16 LZ4_readLE16(const void* memPtr)
     }
 }
 
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
 static U32 LZ4_readLE32(const void* memPtr)
 {
     if (LZ4_isLittleEndian()) {
@@ -440,6 +441,7 @@ static U32 LZ4_readLE32(const void* memPtr)
         return (U32)p[0] + (p[1]<<8) + (p[2]<<16) + (p[3]<<24);
     }
 }
+#endif
 
 static void LZ4_writeLE16(void* memPtr, U16 value)
 {
@@ -789,7 +791,12 @@ LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
 LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
 {
     if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
+
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
     return LZ4_hash4(LZ4_readLE32(p), tableType);
+#else
+    return LZ4_hash4(LZ4_read32(p), tableType);
+#endif
 }
 
 LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)


### PR DESCRIPTION
In the process of porting ClickHouse to `s390x`, I stumbled upon the fact that `lz4` produces different output on `s390x` and `x86-64`. Because of this, checksums of binary artifacts don't match for columns compressed using `lz4`. The root cause of the difference comes down to endianness.

I have a feature proposal to unify the output produced on platforms of different endianness. The reference for this would be the little-endian version. I submitted a PR to the `lz4` repository (https://github.com/lz4/lz4/pull/1253) and the maintainer has indicated around two weeks ago that they welcome my proposal from a theoretical perspective (https://github.com/lz4/lz4/pull/1253#issuecomment-1674012906) and one of the main contributors replied that they like the changes (https://github.com/lz4/lz4/pull/1253#issuecomment-1680726545). As a result, I believe that we can rely on this feature making it into a public release sometime in the future.

However, we have a production deadline for `s390x` support inching ever closer, so I'd like to merge a copy of my changes to this fork for the time being so that my changes can make it into ClickHouse. Please note that it would only have any impact on big-endian platforms, while little-endian ones should remain the same as before.